### PR TITLE
chore: prepare for v0.1.0 PyPI release

### DIFF
--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -1,0 +1,41 @@
+name: Publish to TestPyPI
+
+on:
+  workflow_dispatch:  # Allows manual triggering
+
+permissions:
+  contents: read
+
+jobs:
+  publish-test:
+    name: Build and publish to TestPyPI
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/energyunits
+
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/energyunits
+
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -32,6 +32,6 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         run: |
-          python -m pytest --import-mode=append tests/ --cov=pytemplate tests/
+          python -m pytest --import-mode=append tests/ --cov=energyunits tests/
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,93 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-11-14
+
+### Added
+- **Core Unit Conversion System**
+  - Support for energy units (Wh, kWh, MWh, GWh, TWh, PWh, J, kJ, MJ, GJ, TJ, PJ, EJ, MMBTU)
+  - Support for power units (W, kW, MW, GW, TW)
+  - Support for mass units (g, kg, t, Mt, Gt)
+  - Support for volume units (L, m3, barrel)
+  - Support for time units (s, min, h, a)
+  - Support for currency units (USD, EUR, GBP, JPY, CNY)
+  - Unified `.to()` conversion method for all conversion types
+
+- **Substance-Aware Conversions**
+  - Comprehensive fuel properties database with 20+ substances
+  - Fossil fuels: coal (bituminous, sub-bituminous, lignite), natural gas, LNG, methane, crude oil, diesel, gasoline
+  - Renewable fuels: wood pellets, wood chips, hydrogen
+  - Zero-carbon sources: wind, solar, hydro, nuclear
+  - Combustion products: CO2, H2O, ash
+  - Heating value conversions (HHV/LHV basis)
+  - Automatic basis conversion between HHV and LHV
+
+- **Inflation Adjustment**
+  - Historical inflation rates for USD and EUR (2010-2030)
+  - Automatic currency detection from units
+  - Cumulative inflation calculation
+  - Reference year tracking in conversions
+
+- **Smart Arithmetic Operations**
+  - Natural multiplication: power × time = energy
+  - Natural division: energy ÷ time = power
+  - Compound unit cancellation (e.g., USD/kW × MW = USD)
+  - Dimensional analysis for operation validation
+  - Comparison operations (<, >, ==, <=, >=, !=)
+  - Addition/subtraction with automatic unit conversion
+
+- **Data-Driven Architecture**
+  - All unit definitions stored in JSON (units.json)
+  - All substance properties in JSON (substances.json)
+  - All inflation rates in JSON (inflation.json)
+  - Dimensional multiplication rules in data layer
+  - Dimensional division rules in data layer
+  - Extensible via custom JSON files
+
+- **Array and Data Frame Support**
+  - Full NumPy array support for batch calculations
+  - Time series operations
+  - Optional pandas integration with unit metadata preservation
+  - Bulk conversion operations
+
+- **Advanced Features**
+  - Multi-step conversion chains (mass → energy → emissions)
+  - Complex compound units (USD/MWh, MWh/t, etc.)
+  - Metadata preservation (substance, basis, reference_year)
+  - Custom unit/substance loading from external files
+
+### Development & Quality
+- Comprehensive test suite with 199+ tests across 15 test files
+- CI/CD pipeline with GitHub Actions (Python 3.9-3.13)
+- Code coverage tracking with Codecov (80% target)
+- Black code formatting enforcement
+- Isort import sorting
+- Flake8 linting
+- Type hints throughout codebase
+- Sphinx documentation setup
+- README examples validated as executable tests
+
+### Documentation
+- Comprehensive README with quick start guide
+- Multiple use case examples (energy system analysis, techno-economic modeling, fuel analysis)
+- Advanced features documentation
+- Extensibility guide with JSON examples
+- Complete unit and substance reference tables
+- Inline code documentation with docstrings
+- Example scripts in `/examples` directory
+
+## [0.0.1] - 2024 (Initial Development)
+
+### Added
+- Initial project structure
+- Basic quantity and registry implementation
+- Core conversion functionality
+
+---
+
+[0.1.0]: https://github.com/0-k/energyunits/releases/tag/v0.1.0
+[0.0.1]: https://github.com/0-k/energyunits/releases/tag/v0.0.1

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,217 @@
+# Release Process for EnergyUnits
+
+This document describes how to release a new version of EnergyUnits to PyPI.
+
+## Prerequisites
+
+### 1. Set up PyPI Trusted Publishing
+
+The project uses PyPI's trusted publishing (OpenID Connect) which is more secure than API tokens. You need to configure this once:
+
+#### For TestPyPI (recommended to test first):
+
+1. Go to https://test.pypi.org and log in (create account if needed)
+2. Go to Account Settings → Publishing → Add a new pending publisher
+3. Fill in the form:
+   - **PyPI Project Name**: `energyunits`
+   - **Owner**: `0-k` (your GitHub username/org)
+   - **Repository name**: `energyunits`
+   - **Workflow name**: `publish-test.yml`
+   - **Environment name**: `testpypi`
+4. Click "Add"
+
+#### For PyPI (production):
+
+1. Go to https://pypi.org and log in
+2. Go to Account Settings → Publishing → Add a new pending publisher
+3. Fill in the form:
+   - **PyPI Project Name**: `energyunits`
+   - **Owner**: `0-k`
+   - **Repository name**: `energyunits`
+   - **Workflow name**: `publish.yml`
+   - **Environment name**: `pypi`
+4. Click "Add"
+
+### 2. Create GitHub Environments
+
+Create the required environments in your GitHub repository:
+
+1. Go to your repository on GitHub
+2. Navigate to Settings → Environments
+3. Create two environments:
+   - **testpypi** (for test releases)
+   - **pypi** (for production releases)
+4. (Optional) Add protection rules to require approval before publishing
+
+## Release Process
+
+### Step 1: Update Version
+
+Update the version number in two places:
+
+```bash
+# In pyproject.toml
+version = "X.Y.Z"
+
+# In energyunits/__init__.py
+__version__ = "X.Y.Z"
+```
+
+### Step 2: Update CHANGELOG
+
+Add release notes to `CHANGELOG.md` following the existing format:
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### Added
+- New features
+
+### Changed
+- Changes to existing functionality
+
+### Fixed
+- Bug fixes
+
+### Deprecated
+- Soon-to-be removed features
+
+### Removed
+- Removed features
+
+### Security
+- Security fixes
+```
+
+### Step 3: Test the Build Locally
+
+```bash
+# Install build tools
+pip install build twine
+
+# Build the package
+python -m build
+
+# Check the built package
+twine check dist/*
+
+# Optionally, test install locally
+pip install dist/energyunits-X.Y.Z-py3-none-any.whl
+```
+
+### Step 4: Commit and Push
+
+```bash
+git add pyproject.toml energyunits/__init__.py CHANGELOG.md
+git commit -m "chore: bump version to X.Y.Z"
+git push origin main
+```
+
+### Step 5: Test on TestPyPI (Recommended)
+
+1. Go to GitHub Actions
+2. Select "Publish to TestPyPI" workflow
+3. Click "Run workflow" → "Run workflow"
+4. Wait for the workflow to complete
+5. Test installing from TestPyPI:
+   ```bash
+   pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple energyunits
+   ```
+
+### Step 6: Create a GitHub Release
+
+1. Go to your repository on GitHub
+2. Click "Releases" → "Create a new release"
+3. Click "Choose a tag" and create a new tag: `vX.Y.Z` (e.g., `v0.1.0`)
+4. Set the release title: `vX.Y.Z`
+5. Copy the relevant section from CHANGELOG.md into the release description
+6. Click "Publish release"
+
+### Step 7: Automatic PyPI Publishing
+
+Once you publish the release, the GitHub Action will automatically:
+1. Build the package
+2. Publish to PyPI
+
+You can monitor the progress in the "Actions" tab.
+
+### Step 8: Verify the Release
+
+1. Check that the package appears on PyPI: https://pypi.org/project/energyunits/
+2. Test installing the package:
+   ```bash
+   pip install energyunits
+   ```
+3. Verify the version:
+   ```bash
+   python -c "import energyunits; print(energyunits.__version__)"
+   ```
+
+## Troubleshooting
+
+### Trusted Publishing Not Set Up
+
+**Error**: `Error: Invalid or non-existent authentication information`
+
+**Solution**: Make sure you've configured trusted publishing on PyPI/TestPyPI (see Prerequisites above).
+
+### Environment Not Found
+
+**Error**: `Environment not found`
+
+**Solution**: Create the required environments in GitHub repository settings.
+
+### Build Fails
+
+**Error**: Build process fails during GitHub Action
+
+**Solution**:
+1. Check the GitHub Actions logs
+2. Try building locally with `python -m build`
+3. Ensure all files are committed and pushed
+
+### Package Already Exists
+
+**Error**: `File already exists`
+
+**Solution**: You cannot re-upload the same version. Increment the version number and try again.
+
+## Version Numbering
+
+EnergyUnits follows [Semantic Versioning](https://semver.org/):
+
+- **MAJOR** version (X.0.0): Incompatible API changes
+- **MINOR** version (0.X.0): New functionality, backwards compatible
+- **PATCH** version (0.0.X): Bug fixes, backwards compatible
+
+Examples:
+- `0.1.0` → `0.1.1`: Bug fix release
+- `0.1.0` → `0.2.0`: New features, backwards compatible
+- `0.9.0` → `1.0.0`: First stable release with API guarantees
+- `1.0.0` → `2.0.0`: Breaking changes to API
+
+## Pre-releases
+
+For alpha/beta releases, append to the version:
+
+```
+version = "0.2.0a1"  # Alpha release
+version = "0.2.0b1"  # Beta release
+version = "0.2.0rc1" # Release candidate
+```
+
+## Quick Reference
+
+```bash
+# Complete release checklist
+1. Update version in pyproject.toml and __init__.py
+2. Update CHANGELOG.md
+3. python -m build
+4. twine check dist/*
+5. git commit -am "chore: bump version to X.Y.Z"
+6. git push
+7. Test on TestPyPI (via GitHub Actions)
+8. Create GitHub release with tag vX.Y.Z
+9. Automatic PyPI publish
+10. Verify on PyPI
+```

--- a/energyunits/__init__.py
+++ b/energyunits/__init__.py
@@ -38,7 +38,7 @@ except ImportError:
     _has_pandas = False
     pandas_tools = None
 
-__version__ = "0.0.1"
+__version__ = "0.1.0"
 
 # Define public API
 __all__ = ["Quantity"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "energyunits"
-version = "0.0.1"
+version = "0.1.0"
 authors = [
   { name="Martin Klein", email="hi@martinklein.co" },
 ]
@@ -17,8 +17,20 @@ dependencies = [
     "numpy>=1.26.0",
 ]
 classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Developers",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Physics",
+    "Topic :: Software Development :: Libraries :: Python Modules",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
+    "Typing :: Typed",
 ]
 
 [project.optional-dependencies]
@@ -38,3 +50,12 @@ dev = [
 "Homepage" = "https://github.com/0-k/energyunits"
 "Documentation" = "https://energyunits.readthedocs.io/en/latest/"
 "Bug Tracker" = "https://github.com/0-k/energyunits/issues"
+"Source Code" = "https://github.com/0-k/energyunits"
+"Changelog" = "https://github.com/0-k/energyunits/blob/main/CHANGELOG.md"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["energyunits*"]
+
+[tool.setuptools.package-data]
+energyunits = ["data/*.json"]


### PR DESCRIPTION
This commit prepares the package for its first PyPI release:

- Bump version from 0.0.1 to 0.1.0 in pyproject.toml and __init__.py
- Add comprehensive CHANGELOG.md documenting all features in v0.1.0
- Enhance package metadata with proper classifiers and project URLs
- Configure package to include JSON data files
- Add GitHub Actions workflows for PyPI publishing:
  - publish.yml: Automated publishing on GitHub releases
  - publish-test.yml: Manual TestPyPI publishing for testing
- Add RELEASE.md with detailed release process documentation
- Fix CI workflow to use correct package name in pytest coverage

The package is now ready for publishing to PyPI using trusted publishing.